### PR TITLE
feat: slideshow order, subfolder scan, toast config, and session persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ pids/
 # Claude Code local settings (keep .claude/settings.json but not local overrides)
 .claude/settings.local.json
 
+# Git worktrees
+.worktrees/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/app/src-tauri/src/slideshow.rs
+++ b/app/src-tauri/src/slideshow.rs
@@ -6,28 +6,37 @@ use tauri::Emitter;
 
 #[derive(Default)]
 pub struct SlideshowState {
-    pub folder:  Mutex<Option<PathBuf>>,
-    pub photos:  Mutex<Vec<PathBuf>>,
-    pub watcher: Mutex<Option<RecommendedWatcher>>,
+    pub folder:    Mutex<Option<PathBuf>>,
+    pub photos:    Mutex<Vec<PathBuf>>,
+    pub watcher:   Mutex<Option<RecommendedWatcher>>,
+    pub recursive: Mutex<bool>,
 }
 
 static PHOTO_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp", "gif", "bmp"];
 
-pub fn collect_photos(folder: &PathBuf) -> Vec<PathBuf> {
-    let Ok(entries) = std::fs::read_dir(folder) else { return vec![] };
-    let mut photos: Vec<PathBuf> = entries
-        .flatten()
-        .map(|e| e.path())
-        .filter(|p| {
-            p.is_file()
-                && p.extension()
-                    .and_then(|e| e.to_str())
-                    .map(|e| PHOTO_EXTENSIONS.contains(&e.to_lowercase().as_str()))
-                    .unwrap_or(false)
-        })
-        .collect();
+pub fn collect_photos(folder: &std::path::Path, recursive: bool) -> Vec<PathBuf> {
+    let mut photos = Vec::new();
+    collect_photos_inner(folder, recursive, &mut photos);
     photos.sort();
     photos
+}
+
+fn collect_photos_inner(folder: &std::path::Path, recursive: bool, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(folder) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() && recursive {
+            collect_photos_inner(&path, recursive, out);
+        } else if path.is_file()
+            && path
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|e| PHOTO_EXTENSIONS.contains(&e.to_lowercase().as_str()))
+                .unwrap_or(false)
+        {
+            out.push(path);
+        }
+    }
 }
 
 #[derive(Serialize, Clone)]
@@ -38,6 +47,7 @@ pub struct PhotoListPayload {
 #[tauri::command]
 pub fn watch_folder(
     path: String,
+    recursive: bool,
     state: tauri::State<Arc<SlideshowState>>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
@@ -46,21 +56,16 @@ pub fn watch_folder(
         return Err(format!("Not a directory: {path}"));
     }
 
-    let photos = collect_photos(&folder);
-    {
-        let mut f = state.folder.lock().unwrap();
-        *f = Some(folder.clone());
-        let mut p = state.photos.lock().unwrap();
-        *p = photos.clone();
-    }
+    let photos = collect_photos(&folder, recursive);
+    { *state.folder.lock().unwrap()    = Some(folder.clone()); }
+    { *state.photos.lock().unwrap()    = photos.clone(); }
+    { *state.recursive.lock().unwrap() = recursive; }
 
-    // Emit initial list
     let payload = PhotoListPayload {
         paths: photos.iter().map(|p| p.to_string_lossy().into_owned()).collect(),
     };
-    app.emit("photo-list", payload.clone()).map_err(|e| e.to_string())?;
+    app.emit("photo-list", payload).map_err(|e| e.to_string())?;
 
-    // Spawn filesystem watcher
     let state_arc = Arc::clone(&*state);
     let app2 = app.clone();
     let folder2 = folder.clone();
@@ -70,7 +75,8 @@ pub fn watch_folder(
             use notify::EventKind::*;
             match event.kind {
                 Create(_) | Remove(_) | Modify(notify::event::ModifyKind::Name(_)) => {
-                    let new_photos = collect_photos(&folder2);
+                    let is_recursive = *state_arc.recursive.lock().unwrap();
+                    let new_photos = collect_photos(&folder2, is_recursive);
                     let mut p = state_arc.photos.lock().unwrap();
                     *p = new_photos.clone();
                     let payload = PhotoListPayload {
@@ -84,9 +90,12 @@ pub fn watch_folder(
     })
     .map_err(|e| e.to_string())?;
 
-    watcher
-        .watch(&folder, RecursiveMode::NonRecursive)
-        .map_err(|e| e.to_string())?;
+    let watch_mode = if recursive {
+        RecursiveMode::Recursive
+    } else {
+        RecursiveMode::NonRecursive
+    };
+    watcher.watch(&folder, watch_mode).map_err(|e| e.to_string())?;
 
     *state.watcher.lock().unwrap() = Some(watcher);
     Ok(())
@@ -110,7 +119,7 @@ mod tests {
 
     #[test]
     fn collect_photos_filters_extensions() {
-        let dir = std::env::temp_dir().join("party_display_test_photos");
+        let dir = std::env::temp_dir().join("party_display_test_flat");
         fs::create_dir_all(&dir).unwrap();
 
         let keep = ["a.jpg", "b.jpeg", "c.png", "d.webp"];
@@ -120,22 +129,49 @@ mod tests {
             fs::write(dir.join(name), b"").unwrap();
         }
 
-        let result = collect_photos(&dir);
+        let result = collect_photos(&dir, false);
         let names: Vec<&str> = result
             .iter()
             .map(|p| p.file_name().unwrap().to_str().unwrap())
             .collect();
 
-        for k in &keep {
-            assert!(names.contains(k), "expected {k} in result");
-        }
-        for s in &skip {
-            assert!(!names.contains(s), "did not expect {s} in result");
-        }
+        for k in &keep { assert!(names.contains(k), "expected {k}"); }
+        for s in &skip { assert!(!names.contains(s), "did not expect {s}"); }
 
-        // cleanup
         for name in keep.iter().chain(skip.iter()) {
             let _ = fs::remove_file(dir.join(name));
         }
+    }
+
+    #[test]
+    fn collect_photos_recursive_finds_nested() {
+        let root = std::env::temp_dir().join("party_display_test_recursive");
+        let sub  = root.join("sub");
+        fs::create_dir_all(&sub).unwrap();
+
+        fs::write(root.join("top.jpg"), b"").unwrap();
+        fs::write(sub.join("nested.png"), b"").unwrap();
+        fs::write(sub.join("skip.txt"), b"").unwrap();
+
+        let flat      = collect_photos(&root, false);
+        let recursive = collect_photos(&root, true);
+
+        let flat_names: Vec<&str> = flat.iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap()).collect();
+        let rec_names: Vec<&str> = recursive.iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap()).collect();
+
+        assert!(flat_names.contains(&"top.jpg"));
+        assert!(!flat_names.contains(&"nested.png"), "flat should not find nested");
+
+        assert!(rec_names.contains(&"top.jpg"));
+        assert!(rec_names.contains(&"nested.png"), "recursive should find nested");
+        assert!(!rec_names.contains(&"skip.txt"));
+
+        let _ = fs::remove_file(root.join("top.jpg"));
+        let _ = fs::remove_file(sub.join("nested.png"));
+        let _ = fs::remove_file(sub.join("skip.txt"));
+        let _ = fs::remove_dir(&sub);
+        let _ = fs::remove_dir(&root);
     }
 }

--- a/app/src/components/DisplaySettingsPanel.tsx
+++ b/app/src/components/DisplaySettingsPanel.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react'
+import { emit } from '@tauri-apps/api/event'
+
+export interface DisplaySettings {
+  toastDurationMs: number
+  songZoom:        number
+  volumeZoom:      number
+}
+
+export function readDisplaySettings(): DisplaySettings {
+  return {
+    toastDurationMs: Number(localStorage.getItem('pd_toast_duration_ms') ?? '5000'),
+    songZoom:        Number(localStorage.getItem('pd_song_toast_zoom')    ?? '1'),
+    volumeZoom:      Number(localStorage.getItem('pd_volume_toast_zoom')  ?? '1'),
+  }
+}
+
+const label: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', gap: 8, color: '#ccc', fontSize: 14,
+}
+
+const numInput: React.CSSProperties = {
+  width: 56, background: '#222', border: '1px solid #444', color: '#eee',
+  borderRadius: 4, padding: '3px 6px', fontFamily: 'monospace', fontSize: 13,
+}
+
+export function DisplaySettingsPanel() {
+  const [settings, setSettings] = useState<DisplaySettings>(readDisplaySettings)
+
+  // Sync to localStorage and notify display window on every settings change
+  useEffect(() => {
+    localStorage.setItem('pd_toast_duration_ms', String(settings.toastDurationMs))
+    localStorage.setItem('pd_song_toast_zoom',    String(settings.songZoom))
+    localStorage.setItem('pd_volume_toast_zoom',  String(settings.volumeZoom))
+    emit('display-settings-changed', settings).catch(console.error)
+  }, [settings])
+
+  function set(patch: Partial<DisplaySettings>) {
+    setSettings(s => ({ ...s, ...patch }))
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <p style={{ margin: 0, color: '#888', fontSize: 12, textTransform: 'uppercase', letterSpacing: 1 }}>
+        Display
+      </p>
+
+      {/* Toast duration */}
+      <label style={label}>
+        Toast duration
+        <input
+          type="number" min={1} max={60}
+          value={Math.round(settings.toastDurationMs / 1000)}
+          onChange={e => set({ toastDurationMs: Math.max(1, Number(e.target.value)) * 1000 })}
+          style={numInput}
+        />
+        s
+      </label>
+
+      {/* Song toast zoom */}
+      <label style={label}>
+        Song toast size
+        <input
+          type="number" min={0.5} max={3} step={0.1}
+          value={settings.songZoom}
+          onChange={e => set({ songZoom: Math.min(3, Math.max(0.5, Number(e.target.value))) })}
+          style={numInput}
+        />
+        ×
+      </label>
+
+      {/* Volume toast zoom */}
+      <label style={label}>
+        Volume toast size
+        <input
+          type="number" min={0.5} max={3} step={0.1}
+          value={settings.volumeZoom}
+          onChange={e => set({ volumeZoom: Math.min(3, Math.max(0.5, Number(e.target.value))) })}
+          style={numInput}
+        />
+        ×
+      </label>
+    </div>
+  )
+}

--- a/app/src/components/DisplaySettingsPanel.tsx
+++ b/app/src/components/DisplaySettingsPanel.tsx
@@ -51,7 +51,7 @@ export function DisplaySettingsPanel() {
         <input
           type="number" min={1} max={60}
           value={Math.round(settings.toastDurationMs / 1000)}
-          onChange={e => set({ toastDurationMs: Math.max(1, Number(e.target.value)) * 1000 })}
+          onChange={e => set({ toastDurationMs: Math.min(60, Math.max(1, Number(e.target.value))) * 1000 })}
           style={numInput}
         />
         s

--- a/app/src/components/SlideshowConfigPanel.tsx
+++ b/app/src/components/SlideshowConfigPanel.tsx
@@ -1,13 +1,17 @@
 export interface SlideshowConfig {
-  mode:         'fixed' | 'beat'
-  fixedSec:     number   // seconds between advances in fixed mode  (default 5)
-  beatMinSec:   number   // minimum seconds between advances in beat mode (default 3)
+  mode:       'fixed' | 'beat'
+  fixedSec:   number
+  beatMinSec: number
+  order:      'shuffle' | 'alpha'
+  subfolders: boolean
 }
 
 export const DEFAULT_SLIDESHOW_CONFIG: SlideshowConfig = {
   mode:       'fixed',
   fixedSec:   5,
   beatMinSec: 3,
+  order:      'shuffle',
+  subfolders: false,
 }
 
 interface Props {
@@ -53,44 +57,50 @@ export function SlideshowConfigPanel({ config, onChange, hasPhotos, paused, onTo
         </button>
       </div>
 
-      {/* Fixed interval */}
+      {/* Advance mode */}
       <label style={label}>
-        <input
-          type="radio"
-          checked={config.mode === 'fixed'}
-          onChange={() => set({ mode: 'fixed' })}
-        />
+        <input type="radio" checked={config.mode === 'fixed'} onChange={() => set({ mode: 'fixed' })} />
         Fixed — every
         <input
-          type="number"
-          min={1}
-          max={3600}
-          value={config.fixedSec}
+          type="number" min={1} max={3600} value={config.fixedSec}
           onChange={e => set({ fixedSec: Math.max(1, Number(e.target.value)) })}
-          style={numInput}
-          disabled={config.mode !== 'fixed'}
+          style={numInput} disabled={config.mode !== 'fixed'}
         />
         seconds
       </label>
 
-      {/* Beat sync */}
       <label style={label}>
-        <input
-          type="radio"
-          checked={config.mode === 'beat'}
-          onChange={() => set({ mode: 'beat' })}
-        />
+        <input type="radio" checked={config.mode === 'beat'} onChange={() => set({ mode: 'beat' })} />
         Follow beat — min
         <input
-          type="number"
-          min={1}
-          max={60}
-          value={config.beatMinSec}
+          type="number" min={1} max={60} value={config.beatMinSec}
           onChange={e => set({ beatMinSec: Math.max(1, Number(e.target.value)) })}
-          style={numInput}
-          disabled={config.mode !== 'beat'}
+          style={numInput} disabled={config.mode !== 'beat'}
         />
         seconds between changes
+      </label>
+
+      {/* Photo order */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginTop: 4 }}>
+        <span style={{ color: '#888', fontSize: 12 }}>Order:</span>
+        <label style={label}>
+          <input type="radio" checked={config.order === 'shuffle'} onChange={() => set({ order: 'shuffle' })} />
+          Shuffle
+        </label>
+        <label style={label}>
+          <input type="radio" checked={config.order === 'alpha'} onChange={() => set({ order: 'alpha' })} />
+          Alphabetic
+        </label>
+      </div>
+
+      {/* Subfolders */}
+      <label style={label}>
+        <input
+          type="checkbox"
+          checked={config.subfolders}
+          onChange={e => set({ subfolders: e.target.checked })}
+        />
+        Include subfolders
       </label>
 
       {!hasPhotos && (

--- a/app/src/components/SongToast.tsx
+++ b/app/src/components/SongToast.tsx
@@ -7,9 +7,12 @@ export interface TrackChangedPayload {
   albumArt: string
 }
 
-const DISPLAY_MS = 5000
+interface Props {
+  displayMs: number
+  zoom:      number
+}
 
-export function SongToast() {
+export function SongToast({ displayMs, zoom }: Props) {
   const [track, setTrack]     = useState<TrackChangedPayload | null>(null)
   const [visible, setVisible] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -19,31 +22,32 @@ export function SongToast() {
       setTrack(payload)
       setVisible(true)
       if (timerRef.current) clearTimeout(timerRef.current)
-      timerRef.current = setTimeout(() => setVisible(false), DISPLAY_MS)
+      timerRef.current = setTimeout(() => setVisible(false), displayMs)
     })
     return () => { unlisten.then(fn => fn()) }
-  }, [])
+  }, [displayMs])
 
   if (!track) return null
 
   return (
     <div style={{
-      position:       'fixed',
-      bottom:         32,
-      left:           32,
-      display:        'flex',
-      alignItems:     'center',
-      gap:            12,
-      background:     'rgba(0,0,0,0.78)',
-      backdropFilter: 'blur(10px)',
-      borderRadius:   12,
-      padding:        '10px 16px 10px 10px',
-      zIndex:         200,
-      maxWidth:       320,
-      opacity:        visible ? 1 : 0,
-      transform:      visible ? 'translateY(0)' : 'translateY(16px)',
-      transition:     'opacity 0.4s ease, transform 0.4s ease',
-      pointerEvents:  'none',
+      position:        'fixed',
+      bottom:          32,
+      left:            32,
+      display:         'flex',
+      alignItems:      'center',
+      gap:             12,
+      background:      'rgba(0,0,0,0.78)',
+      backdropFilter:  'blur(10px)',
+      borderRadius:    12,
+      padding:         '10px 16px 10px 10px',
+      zIndex:          200,
+      maxWidth:        320,
+      opacity:         visible ? 1 : 0,
+      transform:       `scale(${zoom})`,
+      transformOrigin: 'bottom left',
+      transition:      'opacity 0.4s ease',
+      pointerEvents:   'none',
     }}>
       {track.albumArt && (
         <img

--- a/app/src/components/VolumeToast.tsx
+++ b/app/src/components/VolumeToast.tsx
@@ -5,9 +5,12 @@ export interface VolumeChangedPayload {
   volume: number  // 0–1
 }
 
-const DISPLAY_MS = 2500
+interface Props {
+  displayMs: number
+  zoom:      number
+}
 
-export function VolumeToast() {
+export function VolumeToast({ displayMs, zoom }: Props) {
   const [volume, setVolume]   = useState(0)
   const [visible, setVisible] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -17,34 +20,33 @@ export function VolumeToast() {
       setVolume(payload.volume)
       setVisible(true)
       if (timerRef.current) clearTimeout(timerRef.current)
-      timerRef.current = setTimeout(() => setVisible(false), DISPLAY_MS)
+      timerRef.current = setTimeout(() => setVisible(false), displayMs)
     })
     return () => { unlisten.then(fn => fn()) }
-  }, [])
+  }, [displayMs])
 
-  const pct = Math.round(volume * 100)
-
-  // Pick icon based on level
+  const pct  = Math.round(volume * 100)
   const icon = volume === 0 ? '🔇' : volume < 0.4 ? '🔉' : '🔊'
 
   return (
     <div style={{
-      position:       'fixed',
-      bottom:         32,
-      right:          32,
-      display:        'flex',
-      alignItems:     'center',
-      gap:            10,
-      background:     'rgba(0,0,0,0.78)',
-      backdropFilter: 'blur(10px)',
-      borderRadius:   10,
-      padding:        '10px 16px',
-      zIndex:         200,
-      minWidth:       160,
-      opacity:        visible ? 1 : 0,
-      transform:      visible ? 'translateY(0)' : 'translateY(16px)',
-      transition:     'opacity 0.4s ease, transform 0.4s ease',
-      pointerEvents:  'none',
+      position:        'fixed',
+      bottom:          32,
+      right:           32,
+      display:         'flex',
+      alignItems:      'center',
+      gap:             10,
+      background:      'rgba(0,0,0,0.78)',
+      backdropFilter:  'blur(10px)',
+      borderRadius:    10,
+      padding:         '10px 16px',
+      zIndex:          200,
+      minWidth:        160,
+      opacity:         visible ? 1 : 0,
+      transform:       `scale(${zoom})`,
+      transformOrigin: 'bottom right',
+      transition:      'opacity 0.4s ease',
+      pointerEvents:   'none',
     }}>
       <span style={{ fontSize: 18 }}>{icon}</span>
       <div style={{ flex: 1 }}>
@@ -52,11 +54,8 @@ export function VolumeToast() {
           height: 4, background: '#333', borderRadius: 2, overflow: 'hidden', marginBottom: 4,
         }}>
           <div style={{
-            width:      `${pct}%`,
-            height:     '100%',
-            background: '#1db954',
-            borderRadius: 2,
-            transition: 'width 0.15s ease',
+            width: `${pct}%`, height: '100%', background: '#1db954',
+            borderRadius: 2, transition: 'width 0.15s ease',
           }} />
         </div>
         <div style={{ color: '#aaa', fontSize: 12 }}>{pct}%</div>

--- a/app/src/hooks/usePhotoLibrary.ts
+++ b/app/src/hooks/usePhotoLibrary.ts
@@ -1,37 +1,93 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 
 export interface PhotoLibraryState {
-  folder: string | null
-  photos: string[]
+  folder:       string | null
+  photos:       string[]
+  initialPhoto: string | null
 }
 
-export function usePhotoLibrary() {
-  const [state, setState] = useState<PhotoLibraryState>({ folder: null, photos: [] })
+interface Options {
+  order:     'shuffle' | 'alpha'
+  recursive: boolean
+}
+
+export function usePhotoLibrary({ order, recursive }: Options) {
+  const [state, setState] = useState<PhotoLibraryState>({
+    folder: null, photos: [], initialPhoto: null,
+  })
+
+  // Keep refs so event-handler closures always see latest values without re-subscribing
+  const orderRef  = useRef(order)
+  // Mirrors state.folder for use in non-reactive closures (event handlers)
+  const folderRef = useRef<string | null>(null)
+  orderRef.current = order
+
+  function applyOrder(
+    rawPaths: string[],
+    folderPath: string | null,
+  ): { photos: string[]; initialPhoto: string | null } {
+    if (orderRef.current === 'alpha') {
+      const sorted       = [...rawPaths].sort()
+      const saved        = folderPath ? getSavedLastPhoto(folderPath) : null
+      const initialPhoto = saved && sorted.includes(saved) ? saved : null
+      return { photos: sorted, initialPhoto }
+    }
+    return { photos: shuffle([...rawPaths]), initialPhoto: null }
+  }
 
   // On mount: fetch whatever the watcher already has (handles late-opening display window)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     invoke<string[]>('get_photos').then(paths => {
-      if (paths.length > 0) setState(s => ({ ...s, photos: shuffle([...paths]) }))
-    }).catch(() => {})
+      if (paths.length > 0) {
+        const { photos, initialPhoto } = applyOrder(paths, folderRef.current)
+        setState(s => ({ ...s, photos, initialPhoto }))
+      }
+    }).catch(err => console.error('[usePhotoLibrary] get_photos failed:', err))
   }, [])
 
+  // Re-apply order when `order` prop changes (re-sort or re-shuffle current list)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    setState(s => {
+      if (s.photos.length === 0) return s
+      const { photos, initialPhoto } = applyOrder(s.photos, s.folder)
+      return { ...s, photos, initialPhoto }
+    })
+  }, [order])
+
   // Listen for file-system watcher updates
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     const unlisten = listen<{ paths: string[] }>('photo-list', ({ payload }) => {
-      setState(s => ({ ...s, photos: shuffle([...payload.paths]) }))
+      const { photos, initialPhoto } = applyOrder(payload.paths, folderRef.current)
+      setState(s => ({ ...s, photos, initialPhoto }))
     })
     return () => { unlisten.then(fn => fn()) }
   }, [])
 
   const setFolder = useCallback(async (folder: string) => {
+    folderRef.current = folder
     setState(s => ({ ...s, folder }))
-    await invoke('watch_folder', { path: folder })
-    // initial list comes back via photo-list event emitted by watch_folder
-  }, [])
+    localStorage.setItem('pd_last_folder', folder)
+    await invoke('watch_folder', { path: folder, recursive })
+    // initial list arrives via photo-list event
+  }, [recursive])
 
   return { ...state, setFolder }
+}
+
+function getSavedLastPhoto(folder: string): string | null {
+  const raw = localStorage.getItem('pd_last_photo')
+  if (!raw) return null
+  try {
+    const map: Record<string, string> = JSON.parse(raw)
+    return map[folder] ?? null
+  } catch {
+    return null
+  }
 }
 
 function shuffle<T>(arr: T[]): T[] {

--- a/app/src/lib/spotify-auth.ts
+++ b/app/src/lib/spotify-auth.ts
@@ -15,7 +15,7 @@ function base64url(buf: ArrayBuffer): string {
 
 export async function generatePkce(): Promise<{ verifier: string; challenge: string }> {
   const verifierBytes = randomBytes(64)
-  const verifier      = base64url(verifierBytes.buffer)
+  const verifier      = base64url(verifierBytes.buffer as ArrayBuffer)
   // Challenge must be SHA-256 of the verifier STRING (as UTF-8), not of the raw bytes.
   // Spotify verifies: base64url(sha256(verifier)) === stored_challenge
   const digest        = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))

--- a/app/src/windows/control/ControlPanel.tsx
+++ b/app/src/windows/control/ControlPanel.tsx
@@ -8,6 +8,7 @@ import { FolderPicker } from '../../components/FolderPicker'
 import { DisplayWindowControls } from '../../components/DisplayWindowControls'
 import { PlayerControls } from '../../components/PlayerControls'
 import { SlideshowConfigPanel, DEFAULT_SLIDESHOW_CONFIG } from '../../components/SlideshowConfigPanel'
+import { DisplaySettingsPanel } from '../../components/DisplaySettingsPanel'
 import type { SlideshowConfig } from '../../components/SlideshowConfigPanel'
 import { useAuth } from '../../hooks/useAuth'
 import { useFftData } from '../../hooks/useFftData'
@@ -17,15 +18,36 @@ import { useBeatScheduler } from '../../hooks/useBeatScheduler'
 import { useHotkeys } from '../../hooks/useHotkeys'
 import { advancePhoto } from '../../hooks/useDisplaySync'
 
+function readSlideshowConfig(): SlideshowConfig {
+  return {
+    mode:       (localStorage.getItem('pd_slideshow_mode') as SlideshowConfig['mode'])
+                  ?? DEFAULT_SLIDESHOW_CONFIG.mode,
+    fixedSec:   Number(localStorage.getItem('pd_slideshow_fixed_sec')     ?? DEFAULT_SLIDESHOW_CONFIG.fixedSec),
+    beatMinSec: Number(localStorage.getItem('pd_slideshow_beat_min_sec')  ?? DEFAULT_SLIDESHOW_CONFIG.beatMinSec),
+    order:      (localStorage.getItem('pd_order') as SlideshowConfig['order'])
+                  ?? DEFAULT_SLIDESHOW_CONFIG.order,
+    subfolders: localStorage.getItem('pd_subfolder') === 'true',
+  }
+}
+
 export default function ControlPanel() {
   const { authenticated, loading, accessToken, error: authError, login, logout } = useAuth()
   const player  = useSpotifyPlayer(authenticated ? accessToken : null)
   const bins    = useFftData()
-  const library = usePhotoLibrary()
-
   const [captureError, setCaptureError]     = useState<string | null>(null)
-  const [config, setConfig]                 = useState<SlideshowConfig>(DEFAULT_SLIDESHOW_CONFIG)
+  const [config, setConfigState]            = useState<SlideshowConfig>(readSlideshowConfig)
+  const library = usePhotoLibrary({ order: config.order, recursive: config.subfolders })
+
   const [slideshowPaused, setSlideshowPaused] = useState(false)
+
+  function setConfig(c: SlideshowConfig) {
+    setConfigState(c)
+    localStorage.setItem('pd_slideshow_mode',         c.mode)
+    localStorage.setItem('pd_slideshow_fixed_sec',    String(c.fixedSec))
+    localStorage.setItem('pd_slideshow_beat_min_sec', String(c.beatMinSec))
+    localStorage.setItem('pd_order',                  c.order)
+    localStorage.setItem('pd_subfolder',              String(c.subfolders))
+  }
 
   // ── Photo navigation ──────────────────────────────────────────────────────
   // indexRef = index of the CURRENTLY displayed photo
@@ -35,12 +57,35 @@ export default function ControlPanel() {
     if (library.photos.length === 0) return
     const i = ((idx % library.photos.length) + library.photos.length) % library.photos.length
     indexRef.current = i
-    advancePhoto(library.photos[i]).catch(console.error)
-  }, [library.photos])
+    const photo = library.photos[i]
+    advancePhoto(photo).catch(console.error)
+    if (config.order === 'alpha' && library.folder) {
+      const raw = localStorage.getItem('pd_last_photo')
+      const map: Record<string, string> = raw ? JSON.parse(raw) : {}
+      map[library.folder] = photo
+      localStorage.setItem('pd_last_photo', JSON.stringify(map))
+    }
+  }, [library.photos, library.folder, config.order])
 
   const doNext = useCallback(() => showAt(indexRef.current + 1), [showAt])
   const doPrev = useCallback(() => showAt(indexRef.current - 1), [showAt])
   const togglePause = useCallback(() => setSlideshowPaused(p => !p), [])
+
+  // Seed indexRef from resume position (or 0) whenever the photo list changes
+  useEffect(() => {
+    if (library.photos.length === 0) return
+    const startIdx = library.initialPhoto
+      ? Math.max(0, library.photos.indexOf(library.initialPhoto))
+      : 0
+    showAt(startIdx)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [library.photos]) // showAt and library.initialPhoto change with library.photos
+
+  // Auto-load the last folder on startup
+  useEffect(() => {
+    const lastFolder = localStorage.getItem('pd_last_folder')
+    if (lastFolder) library.setFolder(lastFolder)
+  }, [])
 
   // ── Track-change → emit to display window ────────────────────────────────
   const prevTrackIdRef = useRef<string | null>(null)
@@ -172,6 +217,7 @@ export default function ControlPanel() {
           paused={slideshowPaused}
           onTogglePause={togglePause}
         />
+        <DisplaySettingsPanel />
         <DisplayWindowControls />
       </div>
     </div>

--- a/app/src/windows/display/DisplayWindow.tsx
+++ b/app/src/windows/display/DisplayWindow.tsx
@@ -1,14 +1,17 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
-import { emit } from '@tauri-apps/api/event'
+import { emit, listen } from '@tauri-apps/api/event'
 import { usePhotoLibrary } from '../../hooks/usePhotoLibrary'
 import { useHotkeys } from '../../hooks/useHotkeys'
 import { SlideshowView } from '../../components/SlideshowView'
 import { SongToast } from '../../components/SongToast'
 import { VolumeToast } from '../../components/VolumeToast'
+import { readDisplaySettings } from '../../components/DisplaySettingsPanel'
+import type { DisplaySettings } from '../../components/DisplaySettingsPanel'
 
 export default function DisplayWindow() {
-  const { photos } = usePhotoLibrary()
+  const { photos } = usePhotoLibrary({ order: 'shuffle', recursive: false })
+  const [displaySettings, setDisplaySettings] = useState<DisplaySettings>(readDisplaySettings)
 
   function handleDoubleClick() {
     invoke('toggle_display_fullscreen').catch(console.error)
@@ -22,7 +25,14 @@ export default function DisplayWindow() {
     return () => document.removeEventListener('keydown', onKey)
   }, [])
 
-  // Relay hotkeys from the display window to the control panel via events
+  // Live-update display settings from control panel
+  useEffect(() => {
+    const unlisten = listen<DisplaySettings>('display-settings-changed', ({ payload }) => {
+      setDisplaySettings(payload)
+    })
+    return () => { unlisten.then(fn => fn()) }
+  }, [])
+
   useHotkeys({
     onNext:        () => emit('display-hotkey', { action: 'next'  }).catch(console.error),
     onPrev:        () => emit('display-hotkey', { action: 'prev'  }).catch(console.error),
@@ -32,8 +42,14 @@ export default function DisplayWindow() {
   return (
     <div style={{ width: '100vw', height: '100vh' }} onDoubleClick={handleDoubleClick}>
       <SlideshowView photos={photos} />
-      <SongToast />
-      <VolumeToast />
+      <SongToast
+        displayMs={displaySettings.toastDurationMs}
+        zoom={displaySettings.songZoom}
+      />
+      <VolumeToast
+        displayMs={displaySettings.toastDurationMs}
+        zoom={displaySettings.volumeZoom}
+      />
     </div>
   )
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -14,7 +14,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- **Toast settings**: configurable duration (shared) and zoom scale (per-toast) via new Display Settings panel; changes reflect live in the display window
- **Slideshow order**: shuffle or alphabetic; re-shuffles on folder/mode change; alphabetic mode resumes at last photo per folder across restarts
- **Folder persistence**: last selected folder auto-loads on startup; subfolder scanning toggle (flat or all depths)
- **Config persistence**: all slideshow settings (mode, interval, order, subfolders) and toast settings survive restarts via localStorage
- **Backend**: watch_folder and collect_photos gain a recursive: bool param; SlideshowState stores the flag for use by the FS watcher callback

## Test Plan
- [ ] Pick a photo folder — confirm it auto-restores after restarting the app
- [ ] Switch to Alphabetic order, browse a few photos, restart — confirm it resumes at the last photo
- [ ] Switch to Shuffle — confirm photos re-shuffle; restart — starts from position 0
- [ ] Enable "Include subfolders" — confirm photos from subdirectories appear
- [ ] Adjust Toast duration and zoom in control panel — confirm toasts in display window update immediately
- [ ] Verify slideshow config (mode, interval, beat min) survives restart
- [ ] Run cargo test — 3 tests pass