### PR TITLE
ci(virustotal): add workflow_dispatch for manual re-runs

### DIFF
--- a/.github/workflows/virustotal.yml
+++ b/.github/workflows/virustotal.yml
@@ -3,6 +3,11 @@ name: VirusTotal Scan
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to scan
+        required: true
 
 jobs:
   scan:
@@ -18,7 +23,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh release download "${{ github.event.release.tag_name }}" \
+          gh release download "${{ github.event.release.tag_name || inputs.tag }}" \
             --repo "${{ github.repository }}" \
             --pattern "*.zip" \
             --dir ./assets 2>/dev/null || true
@@ -78,14 +83,14 @@ jobs:
           fi
 
           # Append VirusTotal result to release body
-          CURRENT_BODY=$(gh release view "${{ github.event.release.tag_name }}" \
+          CURRENT_BODY=$(gh release view "${{ github.event.release.tag_name || inputs.tag }}" \
             --repo "${{ github.repository }}" --json body -q '.body')
 
           NOTES_FILE=$(mktemp)
           printf '%s\n\n---\n%s — [View report](%s)\n' \
             "$CURRENT_BODY" "$SUMMARY" "$VT_URL" > "$NOTES_FILE"
 
-          gh release edit "${{ github.event.release.tag_name }}" \
+          gh release edit "${{ github.event.release.tag_name || inputs.tag }}" \
             --repo "${{ github.repository }}" \
             --notes-file "$NOTES_FILE"
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The main limitation inherited from this exploration is that the spectrum analyze
 
 The two WebView2 windows are independent renderer processes that communicate through the Rust backend via Tauri IPC commands and broadcast events. The control panel owns the Spotify SDK instance and forwards playback state to the display window; the display window is purely a consumer — it renders but issues no Spotify API calls of its own.
 
-**Tech stack:** Tauri 2 · Rust · React · TypeScript · Vite · cpal · RustFFT · Butterchurn · rupnp · notify · music-metadata · Spotify Web Playback SDK · Spotify Web API · LRCLIB · Open-Meteo · ip-api.com
+**Tech stack:** Tauri 2 · Rust · React · TypeScript · Vite · cpal · Butterchurn · rupnp · notify · music-metadata · Spotify Web Playback SDK · Spotify Web API · LRCLIB · Open-Meteo · ip-api.com
 
 ---
 
@@ -185,7 +185,6 @@ vcup2/
 | [ip-api.com](https://ip-api.com) | IP-based geolocation for weather auto-detect |
 | [Butterchurn](https://github.com/jberg/butterchurn) | MilkDrop-style WebGL visualizer |
 | [cpal](https://github.com/RustAudio/cpal) | Cross-platform audio I/O — WASAPI loopback capture |
-| [RustFFT](https://github.com/ejmahler/RustFFT) | FFT for real-time audio analysis |
 | [rupnp](https://github.com/jakobhellermann/rupnp) | UPnP/DLNA device discovery and browsing |
 | [notify](https://github.com/notify-rs/notify) | File system watcher for photo folder |
 | [keyring-rs](https://github.com/hwchen/keyring-rs) | Secure credential storage via Windows Credential Store |

--- a/app/src/components/HelpPanel.tsx
+++ b/app/src/components/HelpPanel.tsx
@@ -40,6 +40,7 @@ const CREDITS = [
   { name: 'keyring',                   url: 'https://github.com/hwchen/keyring-rs',     role: 'Secure token storage (Windows Credential Store)' },
   { name: 'music-metadata',            url: 'https://github.com/borewit/music-metadata', role: 'Embedded audio tag parsing (ID3, FLAC, M4A…)' },
   { name: 'React',                     url: 'https://react.dev',                        role: 'UI framework' },
+  { name: 'TypeScript',                url: 'https://www.typescriptlang.org',           role: 'Typed JavaScript' },
   { name: 'Vite',                      url: 'https://vitejs.dev',                       role: 'Frontend build tool' },
 ]
 


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger so VirusTotal scan can be run manually (needed when re-run from UI reuses old commit SHA)
- Uses `github.event.release.tag_name || inputs.tag` so both triggers work

## Test plan
- [ ] Merge to master
- [ ] Actions → VirusTotal Scan → Run workflow → tag: `v0.9.9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)