### PR TITLE
release: v0.9.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,70 +18,20 @@ The app is built on **Tauri v2** (Windows), using **WASAPI loopback** (via Rust)
 
 ---
 
-## Verifying a release
+## Key features
 
-Every release zip is built by GitHub Actions directly from the signed tag and attested via [Sigstore](https://sigstore.dev). You can cryptographically verify that the file you downloaded was produced by this repo's CI pipeline — not assembled on someone's machine.
-
-**Requirements:** [GitHub CLI](https://cli.github.com) (`gh`)
-
-```bash
-gh attestation verify party-display-vX.Y.Z.zip --repo fmpallini/PartyDisplay
-```
-
-A passing result confirms the artifact's provenance. Replace `vX.Y.Z` with the version you downloaded.
-
-You can also verify the SHA-256 checksum against `checksums.txt` bundled in the same release:
-
-```powershell
-# PowerShell
-(Get-FileHash party-display-vX.Y.Z.zip -Algorithm SHA256).Hash.ToLower()
-```
-
----
-
-## Building from source
-
-### Prerequisites
-
-| Requirement | Version | Notes |
-|---|---|---|
-| [Rust](https://rustup.rs) | stable | Install via rustup |
-| [Node.js](https://nodejs.org) | 18+ | npm included |
-| Windows 10/11 | — | WASAPI loopback is Windows-only |
-| [WebView2](https://developer.microsoft.com/microsoft-edge/webview2/) | — | Pre-installed on Windows 11; download for Windows 10 |
-
-### 1. Install dependencies and run
-
-```bash
-cd app
-npm install
-npm run tauri dev
-```
-
-### 2. Build for release
-
-```bash
-cd app
-npm run tauri build
-```
-
-The output binary will be at `app/src-tauri/target/x86_64-pc-windows-msvc/release/party-display.exe`.
-
-> **Note:** The first Rust build takes several minutes — subsequent builds are incremental.
-
-### 3. Run tests
-
-**Frontend** (Vitest):
-```bash
-cd app
-npm test
-```
-
-**Backend** (Rust):
-```bash
-cd app/src-tauri
-cargo test --workspace
-```
+- **Spotify Connect** — registers as a real Spotify device via the Web Playback SDK inside WebView2; full OAuth PKCE with tokens stored in the Windows credential store and automatic refresh across restarts; Client ID entered at runtime via a guided setup screen (no build-time configuration needed)
+- **External audio source** — pass-through mode that forwards system-wide media and volume keys (play/pause, next/prev, volume up/down) via Windows virtual-key codes; WASAPI loopback still drives the visualizer; song info (title, artist, album art) and lyrics fetched automatically via Windows System Media Transport Controls (SMTC) — requires Windows 10 build 1903+
+- **Local audio files** — plays a local folder of audio files (MP3, FLAC, WAV, OGG, M4A, AAC, OPUS) through the built-in HTML5 player; reads embedded metadata (title, artist, album art); alphabetical or shuffle order; optional recursive scan
+- **DLNA / UPnP media** — discovers UPnP/DLNA servers on the local network; browse their containers directly in the control panel; stream audio tracks and photos from any DLNA server (NAS, media server, etc.) via a local HTTP proxy that handles range requests for seeking
+- **Photo slideshow** — watches a local folder or a DLNA container for images (JPEG, PNG, WebP, GIF, BMP, TIFF); shuffle or alphabetical order with resume; 8 transition effects; configurable timing and image fit
+- **MilkDrop visualizer** — Butterchurn WebGL visualizer driven by real-time WASAPI loopback capture (no driver install); three modes: photos only, photo/visualizer split view, fullscreen; 100 bundled presets, add more by dropping `.json` MilkDrop preset files in the `presets/` folder next to the exe; cycle presets manually (PgUp / PgDn), on every track change, or on a configurable timer
+- **Synchronized lyrics** — fetched from LRCLIB (no API key); overlay mode (3-line karaoke) or split-view mode (full scrolling panel alongside the photo); falls back to static text when sync data is unavailable
+- **Corner widgets** — track overlay (artist + title + progress), clock & weather (Open-Meteo, auto-detected or manual city), battery indicator; all four corners supported with graceful stacking
+- **Song & volume toasts** — brief on-screen notifications on track change and volume adjustment, with configurable duration and scale
+- **Display window** — designed for a second monitor, projector, or TV; features native one-click Miracast/TV casting that automatically routes the window and fullscreens it; position persisted across restarts and validated against connected monitors; screensaver/sleep blocked while open
+- **Live settings sync** — all display settings update instantly on the display window without restart; control panel card layout with collapsible sections
+- **Phone remote control** — browser-based remote served over Wi-Fi; control playback, volume, slideshow, presets, and display toggles from any phone on the local network; QR code for quick access
 
 ---
 
@@ -178,20 +128,70 @@ vcup2/
 
 ---
 
-## Key features
+## Building from source
 
-- **Spotify Connect** — registers as a real Spotify device via the Web Playback SDK inside WebView2; full OAuth PKCE with tokens stored in the Windows credential store and automatic refresh across restarts; Client ID entered at runtime via a guided setup screen (no build-time configuration needed)
-- **External audio source** — pass-through mode that forwards system-wide media and volume keys (play/pause, next/prev, volume up/down) via Windows virtual-key codes; WASAPI loopback still drives the visualizer; song info (title, artist, album art) and lyrics fetched automatically via Windows System Media Transport Controls (SMTC) — requires Windows 10 build 1903+
-- **Local audio files** — plays a local folder of audio files (MP3, FLAC, WAV, OGG, M4A, AAC, OPUS) through the built-in HTML5 player; reads embedded metadata (title, artist, album art); alphabetical or shuffle order; optional recursive scan
-- **DLNA / UPnP media** — discovers UPnP/DLNA servers on the local network; browse their containers directly in the control panel; stream audio tracks and photos from any DLNA server (NAS, media server, etc.) via a local HTTP proxy that handles range requests for seeking
-- **Photo slideshow** — watches a local folder or a DLNA container for images (JPEG, PNG, WebP, GIF, BMP, TIFF); shuffle or alphabetical order with resume; 8 transition effects; configurable timing and image fit
-- **MilkDrop visualizer** — Butterchurn WebGL visualizer driven by real-time WASAPI loopback capture (no driver install); three modes: photos only, photo/visualizer split view, fullscreen; 100 bundled presets, add more by dropping `.json` MilkDrop preset files in the `presets/` folder next to the exe; cycle presets manually (PgUp / PgDn), on every track change, or on a configurable timer
-- **Synchronized lyrics** — fetched from LRCLIB (no API key); overlay mode (3-line karaoke) or split-view mode (full scrolling panel alongside the photo); falls back to static text when sync data is unavailable
-- **Corner widgets** — track overlay (artist + title + progress), clock & weather (Open-Meteo, auto-detected or manual city), battery indicator; all four corners supported with graceful stacking
-- **Song & volume toasts** — brief on-screen notifications on track change and volume adjustment, with configurable duration and scale
-- **Display window** — designed for a second monitor, projector, or TV; features native one-click Miracast/TV casting that automatically routes the window and fullscreens it; position persisted across restarts and validated against connected monitors; screensaver/sleep blocked while open
-- **Live settings sync** — all display settings update instantly on the display window without restart; control panel card layout with collapsible sections
-- **Phone remote control** — browser-based remote served over Wi-Fi; control playback, volume, slideshow, presets, and display toggles from any phone on the local network; QR code for quick access
+### Prerequisites
+
+| Requirement | Version | Notes |
+|---|---|---|
+| [Rust](https://rustup.rs) | stable | Install via rustup |
+| [Node.js](https://nodejs.org) | 18+ | npm included |
+| Windows 10/11 | — | WASAPI loopback is Windows-only |
+| [WebView2](https://developer.microsoft.com/microsoft-edge/webview2/) | — | Pre-installed on Windows 11; download for Windows 10 |
+
+### 1. Install dependencies and run
+
+```bash
+cd app
+npm install
+npm run tauri dev
+```
+
+### 2. Build for release
+
+```bash
+cd app
+npm run tauri build
+```
+
+The output binary will be at `app/src-tauri/target/x86_64-pc-windows-msvc/release/party-display.exe`.
+
+> **Note:** The first Rust build takes several minutes — subsequent builds are incremental.
+
+### 3. Run tests
+
+**Frontend** (Vitest):
+```bash
+cd app
+npm test
+```
+
+**Backend** (Rust):
+```bash
+cd app/src-tauri
+cargo test --workspace
+```
+
+---
+
+## Verifying a release
+
+Every release zip is built by GitHub Actions directly from the signed tag and attested via [Sigstore](https://sigstore.dev). You can cryptographically verify that the file you downloaded was produced by this repo's CI pipeline — not assembled on someone's machine.
+
+**Requirements:** [GitHub CLI](https://cli.github.com) (`gh`)
+
+```bash
+gh attestation verify party-display-vX.Y.Z.zip --repo fmpallini/PartyDisplay
+```
+
+A passing result confirms the artifact's provenance. Replace `vX.Y.Z` with the version you downloaded.
+
+You can also verify the SHA-256 checksum against `checksums.txt` bundled in the same release:
+
+```powershell
+# PowerShell
+(Get-FileHash party-display-vX.Y.Z.zip -Algorithm SHA256).Hash.ToLower()
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ The app is built on **Tauri v2** (Windows), using the **Spotify Web Playback SDK
 
 ---
 
+## Verifying a release
+
+Every release zip is built by GitHub Actions directly from the signed tag and attested via [Sigstore](https://sigstore.dev). You can cryptographically verify that the file you downloaded was produced by this repo's CI pipeline — not assembled on someone's machine.
+
+**Requirements:** [GitHub CLI](https://cli.github.com) (`gh`)
+
+```bash
+gh attestation verify party-display-vX.Y.Z.zip --repo fmpallini/PartyDisplay
+```
+
+A passing result confirms the artifact's provenance. Replace `vX.Y.Z` with the version you downloaded.
+
+You can also verify the SHA-256 checksum against `checksums.txt` bundled in the same release:
+
+```powershell
+# PowerShell
+(Get-FileHash party-display-vX.Y.Z.zip -Algorithm SHA256).Hash.ToLower()
+```
+
+---
+
 ## Building from source
 
 ### Prerequisites
@@ -57,7 +78,7 @@ cd app
 npm run tauri build
 ```
 
-The output binary will be at `app/src-tauri/target/release/party-display.exe`.
+The output binary will be at `app/src-tauri/target/x86_64-pc-windows-msvc/release/party-display.exe`.
 
 > **Note:** The first Rust build takes several minutes — subsequent builds are incremental.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Party Display
 
-> A vibe coding exercise — building a real Spotify-connected party display, driven entirely by AI agents.
+> A vibe coding exercise — building a full-featured party display, driven entirely by AI agents.
 
 [![Tests](https://github.com/fmpallini/PartyDisplay/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/fmpallini/PartyDisplay/actions/workflows/test.yml)
 [![Dependabot Updates](https://github.com/fmpallini/PartyDisplay/actions/workflows/dependabot/dependabot-updates/badge.svg?branch=master)](https://github.com/fmpallini/PartyDisplay/actions/workflows/dependabot/dependabot-updates)
@@ -12,9 +12,9 @@
 
 ![Screenshot of Party Display at version v0.9.9](docs/docs%20for%20release/sample_image.png)
 
-Party Display is a desktop application that registers as a **Spotify Connect device** and shows a fullscreen photo slideshow on a projector or TV, synchronized to the music playing. Think of it as a smart jukebox backdrop — your photos, your playlist, your party.
+Party Display is a desktop party utility — a jukebox that throws psychedelic MilkDrop visualizations and your personal photos onto a projector or TV, synced to whatever music is playing. Use any audio source: play from a local folder, stream from a DLNA/UPnP media server, let any external app or website drive the sound, or connect native Spotify integration if you want it. Think of it as a full party backdrop that actually reacts to sound.
 
-The app is built on **Tauri v2** (Windows), using the **Spotify Web Playback SDK** for device registration and playback, **WASAPI loopback** (via Rust) for real-time spectrum visualization, and **LRCLIB** for synchronized lyrics display.
+The app is built on **Tauri v2** (Windows), using **WASAPI loopback** (via Rust) for real-time spectrum visualization, the **Spotify Web Playback SDK** for optional Spotify Connect device registration, and **LRCLIB** for synchronized lyrics display.
 
 ---
 
@@ -50,20 +50,7 @@ You can also verify the SHA-256 checksum against `checksums.txt` bundled in the 
 | Windows 10/11 | — | WASAPI loopback is Windows-only |
 | [WebView2](https://developer.microsoft.com/microsoft-edge/webview2/) | — | Pre-installed on Windows 11; download for Windows 10 |
 
-### 1. Create a Spotify app
-
-1. Go to the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) and create a new app
-2. Fill in any app name and description
-3. Set the redirect URI to:
-   ```
-   http://127.0.0.1:7357/callback
-   ```
-4. Under "Which API/SDKs are you planning to use?" check **Web Playback SDK**
-5. Save, then copy your **Client ID** from the app settings
-
-The Client ID is entered directly in the app on first launch — no environment file needed.
-
-### 2. Install dependencies and run
+### 1. Install dependencies and run
 
 ```bash
 cd app
@@ -71,7 +58,7 @@ npm install
 npm run tauri dev
 ```
 
-### 3. Build for release
+### 2. Build for release
 
 ```bash
 cd app
@@ -82,7 +69,7 @@ The output binary will be at `app/src-tauri/target/x86_64-pc-windows-msvc/releas
 
 > **Note:** The first Rust build takes several minutes — subsequent builds are incremental.
 
-### 4. Run tests
+### 3. Run tests
 
 **Frontend** (Vitest):
 ```bash

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "party-display",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "party-display",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-deep-link": "^2",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "party-display",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "party-display"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "party-display"
-version = "0.9.11"
+version = "0.9.12"
 edition = "2021"
 
 [build-dependencies]

--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -24,7 +24,7 @@ fn main() {
                 .filter_map(|e| {
                     let path = e.path().canonicalize().ok()?;
                     let name = path.file_stem()?.to_str()?.to_string();
-                    let abs  = path.to_str()?.replace('\\', "/");
+                    let abs = path.to_str()?.replace('\\', "/");
                     Some((name, abs))
                 })
                 .collect()
@@ -33,13 +33,9 @@ fn main() {
 
     entries.sort_by(|a, b| a.0.cmp(&b.0));
 
-    let mut code = String::from(
-        "pub static EMBEDDED_PRESETS: &[(&str, &str)] = &[\n",
-    );
+    let mut code = String::from("pub static EMBEDDED_PRESETS: &[(&str, &str)] = &[\n");
     for (name, abs_path) in &entries {
-        code.push_str(&format!(
-            "    ({name:?}, include_str!({abs_path:?})),\n"
-        ));
+        code.push_str(&format!("    ({name:?}, include_str!({abs_path:?})),\n"));
     }
     code.push_str("];\n");
 

--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -1,3 +1,49 @@
+use std::{fs, path::Path};
+
 fn main() {
-    tauri_build::build()
+    tauri_build::build();
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let presets_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("presets")
+        .canonicalize()
+        .expect("presets/ dir not found");
+
+    let mut entries: Vec<(String, String)> = fs::read_dir(&presets_dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.path()
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s.eq_ignore_ascii_case("json"))
+                        .unwrap_or(false)
+                })
+                .filter_map(|e| {
+                    let path = e.path().canonicalize().ok()?;
+                    let name = path.file_stem()?.to_str()?.to_string();
+                    let abs  = path.to_str()?.replace('\\', "/");
+                    Some((name, abs))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut code = String::from(
+        "pub static EMBEDDED_PRESETS: &[(&str, &str)] = &[\n",
+    );
+    for (name, abs_path) in &entries {
+        code.push_str(&format!(
+            "    ({name:?}, include_str!({abs_path:?})),\n"
+        ));
+    }
+    code.push_str("];\n");
+
+    fs::write(Path::new(&out_dir).join("embedded_presets.rs"), code).unwrap();
+
+    println!("cargo:rerun-if-changed={}", presets_dir.display());
 }

--- a/app/src-tauri/src/presets.rs
+++ b/app/src-tauri/src/presets.rs
@@ -6,7 +6,7 @@ fn embedded_presets() -> Vec<PresetFile> {
     EMBEDDED_PRESETS
         .iter()
         .map(|(name, content)| PresetFile {
-            name:    name.to_string(),
+            name: name.to_string(),
             content: content.to_string(),
         })
         .collect()

--- a/app/src-tauri/src/presets.rs
+++ b/app/src-tauri/src/presets.rs
@@ -1,28 +1,27 @@
 pub use party_display_core::presets::{collect_presets_from_dir, PresetFile};
-use std::path::PathBuf;
 
-fn presets_dir() -> PathBuf {
-    if let Ok(exe) = std::env::current_exe() {
-        let candidate = exe
-            .parent()
-            .unwrap_or(std::path::Path::new("."))
-            .join("presets");
-        if candidate.exists() {
-            return candidate;
-        }
-    }
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("..")
-        .join("..")
-        .join("presets")
+include!(concat!(env!("OUT_DIR"), "/embedded_presets.rs"));
+
+fn embedded_presets() -> Vec<PresetFile> {
+    EMBEDDED_PRESETS
+        .iter()
+        .map(|(name, content)| PresetFile {
+            name:    name.to_string(),
+            content: content.to_string(),
+        })
+        .collect()
 }
 
 #[tauri::command]
 pub fn get_presets() -> Vec<PresetFile> {
-    let dir = presets_dir();
-    if !dir.exists() {
-        eprintln!("presets dir not found: {}", dir.display());
-        return vec![];
+    if let Ok(exe) = std::env::current_exe() {
+        let dir = exe
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
+            .join("presets");
+        if dir.exists() {
+            return collect_presets_from_dir(&dir);
+        }
     }
-    collect_presets_from_dir(&dir)
+    embedded_presets()
 }

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Party Display",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "identifier": "com.partydisplay.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/app/src/components/DisplaySettingsPanel.tsx
+++ b/app/src/components/DisplaySettingsPanel.tsx
@@ -78,7 +78,7 @@ export function readDisplaySettings(): DisplaySettings {
     transitionEffect:     safeEnum(localStorage.getItem(KEYS.transitionEffect),     TRANSITION_EFFECT_VALUES, 'random'),
     transitionDurationMs: safeNum(localStorage.getItem(KEYS.transitionDurationMs), 500),
     imageFit:             safeEnum(localStorage.getItem(KEYS.imageFit),             IMAGE_FIT_VALUES,         'contain'),
-    visualizerMode:           safeEnum(localStorage.getItem(KEYS.visualizerMode),           VISUALIZER_MODE_VALUES,          'photos'),
+    visualizerMode:           safeEnum(localStorage.getItem(KEYS.visualizerMode),           VISUALIZER_MODE_VALUES,          'visualizer'),
     visualizerSplitSide:      safeEnum(localStorage.getItem(KEYS.visualizerSplitSide),      VISUALIZER_SIDE_VALUES,          'right'),
     visualizerPresetIndex:    safeNum(localStorage.getItem(KEYS.visualizerPresetIndex),      0),
     visualizerPresetOrder:    safeEnum(localStorage.getItem(KEYS.visualizerPresetOrder),     VISUALIZER_PRESET_ORDER_VALUES,  'shuffle'),

--- a/app/src/windows/control/ControlPanel.tsx
+++ b/app/src/windows/control/ControlPanel.tsx
@@ -169,7 +169,7 @@ export default function ControlPanel() {
   const [presetNames, setPresetNames] = useState<string[]>([])
 
   const [source, setSource] = useState<'spotify' | 'local' | 'dlna' | 'external'>(
-    () => safeEnum(localStorage.getItem(KEYS.audioSource), ['spotify', 'local', 'dlna', 'external'] as const, 'spotify')
+    () => safeEnum(localStorage.getItem(KEYS.audioSource), ['spotify', 'local', 'dlna', 'external'] as const, 'external')
   )
   const [localFolder,    setLocalFolderState] = useState<string | null>(
     () => localStorage.getItem(KEYS.localAudioFolder)

--- a/app/src/windows/control/ControlPanel.tsx
+++ b/app/src/windows/control/ControlPanel.tsx
@@ -230,8 +230,7 @@ export default function ControlPanel() {
       .catch(() => {})
   }, [])
 
-  // Auto-switch to photos mode when user picks a new folder that has photos.
-  // Pre-initialize with the saved folder so app-startup restore doesn't trigger.
+  // Pre-initialize with the saved folder so app-startup restore doesn't trigger auto-switch.
   const autoSwitchedForFolderRef = useRef<string | null>(localStorage.getItem(KEYS.lastPhotoFolder))
   useEffect(() => {
     if (

--- a/app/src/windows/control/ControlPanel.tsx
+++ b/app/src/windows/control/ControlPanel.tsx
@@ -230,6 +230,20 @@ export default function ControlPanel() {
       .catch(() => {})
   }, [])
 
+  // Auto-switch to photos mode when user picks a new folder that has photos.
+  // Pre-initialize with the saved folder so app-startup restore doesn't trigger.
+  const autoSwitchedForFolderRef = useRef<string | null>(localStorage.getItem(KEYS.lastPhotoFolder))
+  useEffect(() => {
+    if (
+      library.folder &&
+      library.photos.length > 0 &&
+      autoSwitchedForFolderRef.current !== library.folder
+    ) {
+      autoSwitchedForFolderRef.current = library.folder
+      setDisplaySettings(s => ({ ...s, visualizerMode: 'photos' }))
+    }
+  }, [library.folder, library.photos.length])
+
   // Notify display window whenever slideshow pause state changes (skip initial mount)
   const slideshowMountedRef = useRef(false)
   useEffect(() => {

--- a/docs/docs for release/README.txt
+++ b/docs/docs for release/README.txt
@@ -13,7 +13,6 @@ REQUIREMENTS
       Already installed on all Windows 11 machines and most Windows 10 machines.
       If missing, download from:
         https://developer.microsoft.com/en-us/microsoft-edge/webview2/
-  - Spotify Premium account (required for Web Playback SDK streaming)
 
 
 HOW TO RUN
@@ -22,49 +21,54 @@ HOW TO RUN
 
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- FIRST LAUNCH — CONNECT SPOTIFY
+ FIRST LAUNCH
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
- 1. Double-click party-display.exe.
+ 1. Double-click party-display.exe — no installation needed.
 
- 2. In the control panel, click "Connect Spotify".
+ 2. The control panel opens with "External" audio source selected.
+    Any audio playing on your PC will drive the visualizer and show
+    song info automatically.
 
- 3. If this is your first launch, you will be prompted to enter your
+ 3. Click "Open Display" to show the visualizer on a second monitor,
+    projector, or TV.
+
+ 4. Optionally pick a photo folder — the app will automatically switch
+    to photo mode when photos are loaded.
+
+
+ OPTIONAL — SPOTIFY INTEGRATION
+
+ If you want to use Party Display as a native Spotify Connect device:
+
+ 1. In the control panel, select the Spotify audio source and click
+    "Connect Spotify".
+
+ 2. If this is your first launch, you will be prompted to enter your
     Spotify Client ID. Follow the on-screen steps to create a free app
     on developer.spotify.com and paste the Client ID. It is stored
     securely in the Windows Credential Store and never needs to be
     entered again.
 
- 4. Your browser will open the Spotify login page. Log in and grant
+ 3. Your browser will open the Spotify login page. Log in and grant
     the requested permissions.
 
- 5. The browser will redirect to 127.0.0.1:7357 (a local page served
+ 4. The browser will redirect to 127.0.0.1:7357 (a local page served
     briefly by the app), then close automatically.
 
- 6. The control panel will show your account as connected.
-    Pick a photo folder, open the display window, and enjoy.
-
- NOTE: A Spotify Premium account is required to stream audio to the
- Party Display player device.
+ NOTE: A Spotify Premium account is required to stream audio through
+ the Party Display Spotify Connect device.
 
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  FEATURES
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
- SPOTIFY
-  - Registers as a Spotify Connect device (Web Playback SDK)
-  - Client ID entered at runtime via guided setup — no config file needed
-  - OAuth PKCE login — tokens saved in Windows Credential Store
-  - Auto token refresh — sessions survive app restarts
-  - Volume synced from your Spotify session on connect
-  - Now playing card: album art, track name, artist, progress bar + seek
-  - Transport controls: play/pause, previous, next, volume
-
  EXTERNAL AUDIO
-  - Pass-through mode for any audio playing on your PC
+  - Pass-through mode for any audio playing on your PC — Spotify, browser,
+    media player, YouTube, whatever
   - Numpad +/- send system-wide volume keys; 4/5/6 send media keys
-  - WASAPI loopback still drives the visualizer
+  - WASAPI loopback drives the visualizer in real time
   - Song info (title, artist, album art) and lyrics fetched automatically when the
     active player registers with the Windows System Media Transport Controls (SMTC)
   - "Active player" = the media session Windows considers current (last interacted with)
@@ -94,6 +98,16 @@ HOW TO RUN
   - Stream audio tracks from a DLNA server (NAS, media server, etc.)
   - Use a DLNA container as the photo slideshow source
   - Seeking supported via HTTP range-request proxy
+
+ SPOTIFY (optional)
+  - Registers as a native Spotify Connect device (Web Playback SDK)
+  - Client ID entered at runtime via guided setup — no config file needed
+  - OAuth PKCE login — tokens saved in Windows Credential Store
+  - Auto token refresh — sessions survive app restarts
+  - Volume synced from your Spotify session on connect
+  - Now playing card: album art, track name, artist, progress bar + seek
+  - Transport controls: play/pause, previous, next, volume
+  - Requires a Spotify Premium account
 
  PHOTO SLIDESHOW
   - Watches a local folder or DLNA container for images

--- a/docs/docs for release/README.txt
+++ b/docs/docs for release/README.txt
@@ -1,4 +1,4 @@
-Party Display v0.9.11 — Windows 64-bit Portable
+Party Display v0.9.12 — Windows 64-bit Portable
 ===============================================
 
   GitHub:  https://github.com/fmpallini/PartyDisplay
@@ -237,6 +237,28 @@ HOW TO RUN
     the Windows media timeline correctly when you open a new YouTube video, or
     they continue counting from the previous video's position. This causes the
     progress bar and lyrics in Party Display to be completely out of sync.
+
+  Spotify via External source vs. native Spotify integration — what's the difference?
+    Both work well for a party, but the native Spotify integration offers more control:
+
+    With External source (Spotify desktop app or browser):
+      - Song info, album art, and lyrics display automatically via Windows SMTC
+      - Volume control adjusts system volume, not Spotify's own volume slider
+      - Track seeking and shuffle control are NOT available
+        through Party Display's control window
+      - Playlist changes must be made at the computer — guests cannot switch
+        playlists from their phones (the Phone Remote only controls Party Display,
+        not Spotify itself)
+      - Requires additional software running (browser or Spotify app)
+
+    With native Spotify integration (Spotify Connect):
+      - Full transport controls: seek bar, shuffle, volume (inside Spotify)
+      - Playlist selection and queue management work from any phone or the
+        Spotify app — no need to touch the party computer
+      - Requires a Spotify Premium account and a one-time Client ID setup
+
+    If Premium is not an option, External mode covers the
+    essentials fine.
 
   Reset everything
     Open the Help panel (? button in the control panel) and click "Reset".


### PR DESCRIPTION
## What's in this release

- **feat:** embed presets in binary — app works out of the box with no external `presets/` folder required; runtime still prefers a sibling `presets/` folder if present
- **feat:** default audio source changed to External on fresh start — zero-config first launch experience
- **feat:** default visualizer mode changed to Visualizer — shows MilkDrop immediately on launch
- **feat:** auto-switch to Photos mode when user picks a new folder that has photos

## Docs
- README reframed around party utility concept; Spotify demoted to optional
- README.txt updated: first-launch flow now leads with External source; Spotify moved to optional section; added External vs Spotify comparison section
- README sections reordered: features moved up, build/verify moved to bottom

## Pre-release checklist
- [x] P1: No missing tests (default changes + UI hooks, not unit-testable)
- [x] P2: Simplify pass — one comment cleanup
- [x] P3: Security review — no findings above threshold
- [x] P4: Bug hunt — no bugs found
- [x] P5: 58 Rust + 216 frontend tests passing